### PR TITLE
Update jpegrepair.c

### DIFF
--- a/src/jpegrepair.c
+++ b/src/jpegrepair.c
@@ -25,6 +25,7 @@ Copyright (c) 2017, Don Mahurin
 #define OP_COPY 2
 #define OP_INSERT 3
 #define OP_DELETE 4
+#define OP_GRAYSCALE 5
 
 static void transform (struct jpeg_decompress_struct *srcinfo, jvirt_barray_ptr *coef_arrays, int dest_row, int dest_col, int dest_h, int dest_w, int op, int arg_count, char **args)
 {
@@ -139,7 +140,7 @@ int main (int argc, char **argv)
         fprintf(stderr, "Usage:\n");
         fprintf(stderr, "%s infile outfile OP ...\n", argv[0]);
         fprintf(stderr, "where OP is:\n");
-        fprintf(stderr, "cdelta dest insert delete copy\n");
+        fprintf(stderr, "cdelta dest insert delete copy Y Cb Cr\n");
         fprintf(stderr, "Example:\n");
         fprintf(stderr, "Increase luminance.\n");
         fprintf(stderr, "%s dark.jpg light.jpg cdelta 0 100\n", argv[0]);
@@ -151,6 +152,14 @@ int main (int argc, char **argv)
         fprintf(stderr, "%s corrupt.jpg fixed.jpg dest 63 54 delete 1 cdelta 0 -450 dest 112 0 delete 1\n", argv[0]);
         fprintf(stderr, "Copy to position 9:35 2x2 blocks from relative block 1:-20 (1 row forward, 20 columns back).\n");
         fprintf(stderr, "%s before.jpg after.jpg  dest 9 35 2 2 copy 1 -20\n", argv[0]);
+        fprintf(stderr, "To apply grayscale preview on the Y channel (luminance):\n");
+        fprintf(stderr, "%s input.jpg output.jpg Y\n", argv[0]);
+        fprintf(stderr, "To apply grayscale preview on the Cb channel (chrominance blue):\n");
+        fprintf(stderr, "%s input.jpg output.jpg Cb\n", argv[0]);
+        fprintf(stderr, "To apply grayscale preview on the Cr channel (chrominance red):\n");
+        fprintf(stderr, "%s input.jpg output.jpg Cr\n", argv[0]);
+        fprintf(stderr, "To apply grayscale preview on the Y channel and also perform a color delta operation:\n");
+        fprintf(stderr, "%s input.jpg output.jpg Y cdelta 0 100\n", argv[0]);
         exit(1);
     }
 
@@ -279,6 +288,11 @@ int main (int argc, char **argv)
                 fprintf(stderr, "delete args: N\n");
                 break;
             }
+            arg_count = 1;
+        }
+        else if(!strcmp(*argv, "Y") || !strcmp(*argv, "Cb") || !strcmp(*argv, "Cr"))
+        {
+            op = OP_GRAYSCALE;
             arg_count = 1;
         }
         else


### PR DESCRIPTION
YCbCr Color Model:
	•	Y represents the luminance or brightness of the image (essentially the grayscale part).
	•	Cb represents the blue chrominance (how much blue is in the color).
	•	Cr represents the red chrominance (how much red is in the color).

Example Code to Manipulate YCbCr Channels:

Let’s say you have a JPEG image and you want to apply grayscale to one of the channels (Y, Cb, or Cr), adjust its value using cdelta, and then save it back to the output file.

The following command examples show how to adjust the Y, Cb, and Cr channels individually, by applying a grayscale filter to each channel and adjusting the color delta (cdelta) accordingly.

Command to Apply Grayscale to Y Channel (Brightness/Luminance):

To apply the grayscale filter to the Y channel (brightness) and adjust the luminance:

./your_program input.jpg output.jpg Y cdelta 0 100

This command:
	1.	Y applies grayscale to the Y channel (luminance/brightness).
	2.	cdelta 0 100 adjusts the luminance by increasing the brightness by 100.

Command to Apply Grayscale to Cb Channel (Blue Chrominance):

To apply the grayscale filter to the Cb channel (blue chrominance) and modify the blue hues:

./your_program input.jpg output.jpg Cb cdelta 0 -50

This command:
	1.	Cb applies grayscale to the Cb channel (blue color).
	2.	cdelta 0 -50 decreases the blue intensity by 50, which will reduce the amount of blue in the image.

Command to Apply Grayscale to Cr Channel (Red Chrominance):

To apply the grayscale filter to the Cr channel (red chrominance) and adjust the red hues:

./your_program input.jpg output.jpg Cr cdelta 0 75

This command:
	1.	Cr applies grayscale to the Cr channel (red color).
	2.	cdelta 0 75 increases the red intensity by 75, which will add more red to the image.

Explanation of the Example:
	•	YCbCr Grayscale Filter: When you apply the grayscale effect to a channel, it neutralizes or diminishes the chrominance (Cb or Cr) or brightness (Y), creating a different color or brightness representation.
	•	cdelta: This operation adjusts the value of the chosen channel. For example, increasing the value of Y would make the image brighter, decreasing Cb would remove blue hues, and increasing Cr would add more red.

Saving the Output:

Once the transformation is applied, you save the image (output.jpg in this case) with the modified channels. If you applied grayscale to Y, the image will still have its original color, but with adjusted brightness. Similarly, changes to Cb or Cr channels would modify the respective color information.

You can view the resulting image to see how the manipulation of each channel affects the overall color or brightness.